### PR TITLE
Always return pointer object on indexing

### DIFF
--- a/h5io_browser/pointer.py
+++ b/h5io_browser/pointer.py
@@ -405,10 +405,7 @@ class Pointer(MutableMapping):
             else:
                 return list(data_dict.values())[-1]
         except (FileNotFoundError, ValueError):
-            if self.file_exists:
-                return self.__class__(file_name=self._file_name, h5_path=h5_path_new)
-            else:
-                return None
+            return self.__class__(file_name=self._file_name, h5_path=h5_path_new)
 
     def __str__(self):
         """


### PR DESCRIPTION
Currently indexing to a non exiting group shows to distinct behaviors.  If the file exists a new pointer object is returned and writing to it will create the group. If the file does not exist None is returned.  This patch makes both cases return a pointer object which creates the underlying file/group once written to it.  Imo this is more convenient for downstream users because otherwise they need to maintain separate code paths for creating new groups in existing and non existing files, since there are no methods to force creation of an empty group (what would be create_group in pyiron_base speak).